### PR TITLE
Upgrade `debug` to resolve CVE-2017-16137

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,9 +3020,9 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Finish resolving CVE-2017-16137
  | Affected versions | Patched versions |
  |-|-|
  | < 2.6.9 | 2.6.9 |
  | >= 3.0.0, < 3.1.0 | 3.1.0 |
  | >= 3.2.0, < 3.2.7 | 3.2.7 |
  | >= 4.0.0, < 4.3.1 | 4.3.1 |
```zsh
   - Hoisted from "@babel#core#debug"
   - Hoisted from "@babel#preset-env#babel-plugin-polyfill-corejs2#@babel#helper-define-polyfill-provider#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#@eslint#eslintrc#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#@humanwhocodes#config-array#debug"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#debug"
   - Hoisted from "babel-eslint#@babel#traverse#debug"
   - Hoisted from "eslint#debug"
   - Hoisted from "eslint-plugin-jest#@typescript-eslint#utils#@typescript-eslint#typescript-estree#debug"
   - Hoisted from "jest#@jest#core#@jest#reporters#istanbul-lib-instrument#@babel#core#debug"
   - Hoisted from "jest#@jest#core#@jest#reporters#istanbul-lib-source-maps#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#agent-base#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#debug"
   - Hoisted from "jest#@jest#core#jest-config#jest-environment-jsdom#jsdom#https-proxy-agent#debug"
[1/4] Why do we have the module "debug"...?
info => Found "debug@4.3.4"
info => Found "eslint-import-resolver-node#debug@2.6.9"
info => Found "eslint-module-utils#debug@2.6.9"
info => Found "eslint-plugin-import#debug@2.6.9"
info => Found "expand-brackets#debug@2.6.9"
info => Found "license-checker#debug@3.2.7"
info => Found "snapdragon#debug@2.6.9"
info Has been hoisted to "debug"
```

# Testing
## How can the other reviewers check that your change works?
build should pass
