### PR TITLE
fix: add path validation in readYaml.js

### DIFF
--- a/src/readYaml.js
+++ b/src/readYaml.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { promises } from "fs";
+import path from "path";
 import yaml from "js-yaml";
 
 const schema = yaml.Schema.create([
@@ -109,6 +110,12 @@ const schema = yaml.Schema.create([
 ]);
 
 export default async function readYaml(filename: string): Promise<mixed> {
-  const contents = await promises.readFile(filename, "utf8");
+  const normalized = path.normalize(filename);
+
+  if (path.isAbsolute(normalized) || normalized.split(path.sep).includes("..")) {
+    throw new Error(`Invalid 'file' input: ${filename} must be a relative path within the workspace.`);
+  }
+
+  const contents = await promises.readFile(normalized, "utf8");
   return yaml.safeLoad(contents, { filename, schema });
 }


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/readYaml.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/readYaml.js:74` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |
| **Chain Complexity** | 2-step |

**Description**: The readYaml function accepts a filename parameter and reads the file without any path validation or sanitization. The filename originates from user-controlled input via the 'file' parameter in the GitHub Actions workflow, allowing an attacker to read arbitrary files from the runner system using path traversal sequences.

## Evidence

**Exploitation scenario**: An attacker with ability to control the 'file' input parameter in a GitHub Actions workflow can provide a malicious path such as '../../../../../../proc/self/environ' to read sensitive environment.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/readYaml.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: File operations never resolve paths outside the declared root directory

<details>
<summary>Regression test</summary>

```javascript
import readYaml from "../src/readYaml.js";
import path from "path";

describe("File operations never resolve paths outside the declared root directory", () => {
  const rootDir = process.cwd();
  const payloads = [
    "../../../etc/passwd",
    "../../../../etc/passwd",
    "./valid-test-file.yaml",
  ];

  test.each(payloads)("rejects or contains path traversal: %s", async (payload) => {
    const resolvedPath = path.resolve(rootDir, payload);
    const isWithinRoot = resolvedPath.startsWith(rootDir + path.sep) || resolvedPath === rootDir;

    if (!isWithinRoot) {
      await expect(readYaml(payload)).rejects.toThrow();
    }
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
